### PR TITLE
Issue #35 reduce point cloud obstacles

### DIFF
--- a/training/orig/demo_manipulation/src/collision_avoidance_pick_and_place/src/tasks/create_motion_plan.cpp
+++ b/training/orig/demo_manipulation/src/collision_avoidance_pick_and_place/src/tasks/create_motion_plan.cpp
@@ -35,7 +35,7 @@ bool PickAndPlace::create_motion_plan(const geometry_msgs::Pose &pose_target,
 	req.group_name = cfg.ARM_GROUP_NAME;
 	req.goal_constraints.push_back(pose_goal);
 	req.allowed_planning_time = 60.0f;
-	req.num_planning_attempts = 10;
+	req.num_planning_attempts = 1;
 
 	// request motion plan
 	bool success = false;

--- a/training/ref/demo_manipulation/src/collision_avoidance_pick_and_place/src/tasks/create_motion_plan.cpp
+++ b/training/ref/demo_manipulation/src/collision_avoidance_pick_and_place/src/tasks/create_motion_plan.cpp
@@ -35,7 +35,7 @@ bool PickAndPlace::create_motion_plan(const geometry_msgs::Pose &pose_target,
 	req.group_name = cfg.ARM_GROUP_NAME;
 	req.goal_constraints.push_back(pose_goal);
 	req.allowed_planning_time = 60.0f;
-	req.num_planning_attempts = 10;
+	req.num_planning_attempts = 1;
 
 	// request motion plan
 	bool success = false;

--- a/training/work/demo_manipulation/src/collision_avoidance_pick_and_place/src/tasks/create_motion_plan.cpp
+++ b/training/work/demo_manipulation/src/collision_avoidance_pick_and_place/src/tasks/create_motion_plan.cpp
@@ -35,7 +35,7 @@ bool PickAndPlace::create_motion_plan(const geometry_msgs::Pose &pose_target,
 	req.group_name = cfg.ARM_GROUP_NAME;
 	req.goal_constraints.push_back(pose_goal);
 	req.allowed_planning_time = 60.0f;
-	req.num_planning_attempts = 10;
+	req.num_planning_attempts = 1;
 
 	// request motion plan
 	bool success = false;


### PR DESCRIPTION
- Reduces path planning time significantly by setting the "num_planning_attempts" variable to 1.  
- Obstacles were kept in the default mode since path planning time does not change noticeably whenever they are used.
