### PR TITLE
Updated symlinks in catkin workspace CMakeLists

### DIFF
--- a/training/orig/1.4/src/CMakeLists.txt
+++ b/training/orig/1.4/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/1.5/src/CMakeLists.txt
+++ b/training/orig/1.5/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/1.6/src/CMakeLists.txt
+++ b/training/orig/1.6/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/2.1/src/CMakeLists.txt
+++ b/training/orig/2.1/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/2.2/src/CMakeLists.txt
+++ b/training/orig/2.2/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/2.3/src/CMakeLists.txt
+++ b/training/orig/2.3/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/2.4/src/CMakeLists.txt
+++ b/training/orig/2.4/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/2.5/src/CMakeLists.txt
+++ b/training/orig/2.5/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/2.6/src/CMakeLists.txt
+++ b/training/orig/2.6/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/2.7/src/CMakeLists.txt
+++ b/training/orig/2.7/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/2.8/src/CMakeLists.txt
+++ b/training/orig/2.8/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/2.8b/src/CMakeLists.txt
+++ b/training/orig/2.8b/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/2.9/src/CMakeLists.txt
+++ b/training/orig/2.9/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/3.4/src/CMakeLists.txt
+++ b/training/orig/3.4/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/3.5/src/CMakeLists.txt
+++ b/training/orig/3.5/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/3.6/src/CMakeLists.txt
+++ b/training/orig/3.6/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/3.7/src/CMakeLists.txt
+++ b/training/orig/3.7/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/4.2/src/CMakeLists.txt
+++ b/training/orig/4.2/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/orig/4.6/src/CMakeLists.txt
+++ b/training/orig/4.6/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/1.4/src/CMakeLists.txt
+++ b/training/ref/1.4/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/1.5/src/CMakeLists.txt
+++ b/training/ref/1.5/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/1.6/src/CMakeLists.txt
+++ b/training/ref/1.6/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/2.1/src/CMakeLists.txt
+++ b/training/ref/2.1/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/2.2/src/CMakeLists.txt
+++ b/training/ref/2.2/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/2.3/src/CMakeLists.txt
+++ b/training/ref/2.3/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/2.4/src/CMakeLists.txt
+++ b/training/ref/2.4/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/2.5/src/CMakeLists.txt
+++ b/training/ref/2.5/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/2.6/src/CMakeLists.txt
+++ b/training/ref/2.6/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/2.7/src/CMakeLists.txt
+++ b/training/ref/2.7/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/2.8/src/CMakeLists.txt
+++ b/training/ref/2.8/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/2.8b/src/CMakeLists.txt
+++ b/training/ref/2.8b/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/2.9/src/CMakeLists.txt
+++ b/training/ref/2.9/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/3.4/src/CMakeLists.txt
+++ b/training/ref/3.4/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/3.5/src/CMakeLists.txt
+++ b/training/ref/3.5/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/3.6/src/CMakeLists.txt
+++ b/training/ref/3.6/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/3.7/src/CMakeLists.txt
+++ b/training/ref/3.7/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/4.2/src/CMakeLists.txt
+++ b/training/ref/4.2/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/ref/4.6/src/CMakeLists.txt
+++ b/training/ref/4.6/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/supplements/src/CMakeLists.txt
+++ b/training/supplements/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/1.4/src/CMakeLists.txt
+++ b/training/work/1.4/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/1.5/src/CMakeLists.txt
+++ b/training/work/1.5/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/1.6/src/CMakeLists.txt
+++ b/training/work/1.6/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/2.1/src/CMakeLists.txt
+++ b/training/work/2.1/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/2.2/src/CMakeLists.txt
+++ b/training/work/2.2/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/2.3/src/CMakeLists.txt
+++ b/training/work/2.3/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/2.4/src/CMakeLists.txt
+++ b/training/work/2.4/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/2.5/src/CMakeLists.txt
+++ b/training/work/2.5/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/2.6/src/CMakeLists.txt
+++ b/training/work/2.6/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/2.7/src/CMakeLists.txt
+++ b/training/work/2.7/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/2.8/src/CMakeLists.txt
+++ b/training/work/2.8/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/2.8b/src/CMakeLists.txt
+++ b/training/work/2.8b/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/2.9/src/CMakeLists.txt
+++ b/training/work/2.9/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/3.4/src/CMakeLists.txt
+++ b/training/work/3.4/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/3.5/src/CMakeLists.txt
+++ b/training/work/3.5/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/3.6/src/CMakeLists.txt
+++ b/training/work/3.6/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/3.7/src/CMakeLists.txt
+++ b/training/work/3.7/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/4.2/src/CMakeLists.txt
+++ b/training/work/4.2/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake

--- a/training/work/4.6/src/CMakeLists.txt
+++ b/training/work/4.6/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake


### PR DESCRIPTION
 to point to /opt/ros/indigo/... instead of /opt/ros/hydro/...
Addresses issue #49 