### PR TITLE
demo_manipulation: remove dependency on pr2ControllerManager

### DIFF
--- a/training/orig/demo_manipulation/src/ur5_collision_avoidance_moveit_config/config/controllers.yaml
+++ b/training/orig/demo_manipulation/src/ur5_collision_avoidance_moveit_config/config/controllers.yaml
@@ -1,8 +1,7 @@
-controller_manager_ns: pr2_controller_manager
 controller_list:
   - name: ""
-    ns: joint_trajectory_action
-    default: true
+    action_ns: joint_trajectory_action
+    type: FollowJointTrajectory
     joints:
       - elbow_joint
       - shoulder_lift_joint

--- a/training/orig/demo_manipulation/src/ur5_collision_avoidance_moveit_config/launch/ur5_collision_avoidance_moveit_controller_manager.launch
+++ b/training/orig/demo_manipulation/src/ur5_collision_avoidance_moveit_config/launch/ur5_collision_avoidance_moveit_controller_manager.launch
@@ -1,9 +1,6 @@
 <launch>
- <arg name="moveit_controller_manager" default="pr2_moveit_controller_manager/Pr2MoveItControllerManager" />
+ <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager" />
  <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
- <arg name="controller_manager_name" default="pr2_controller_manager" />
- <param name="controller_manager_name" value="$(arg controller_manager_name)" />
- <arg name="use_controller_manager" default="false" />
- <param name="use_controller_manager" value="$(arg use_controller_manager)" />
+
  <rosparam file="$(find ur5_collision_avoidance_moveit_config)/config/controllers.yaml"/>
 </launch>

--- a/training/ref/demo_manipulation/src/ur5_collision_avoidance_moveit_config/config/controllers.yaml
+++ b/training/ref/demo_manipulation/src/ur5_collision_avoidance_moveit_config/config/controllers.yaml
@@ -1,8 +1,7 @@
-controller_manager_ns: pr2_controller_manager
 controller_list:
   - name: ""
-    ns: joint_trajectory_action
-    default: true
+    action_ns: joint_trajectory_action
+    type: FollowJointTrajectory
     joints:
       - elbow_joint
       - shoulder_lift_joint

--- a/training/ref/demo_manipulation/src/ur5_collision_avoidance_moveit_config/launch/ur5_collision_avoidance_moveit_controller_manager.launch
+++ b/training/ref/demo_manipulation/src/ur5_collision_avoidance_moveit_config/launch/ur5_collision_avoidance_moveit_controller_manager.launch
@@ -1,9 +1,6 @@
 <launch>
- <arg name="moveit_controller_manager" default="pr2_moveit_controller_manager/Pr2MoveItControllerManager" />
+ <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager" />
  <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
- <arg name="controller_manager_name" default="pr2_controller_manager" />
- <param name="controller_manager_name" value="$(arg controller_manager_name)" />
- <arg name="use_controller_manager" default="false" />
- <param name="use_controller_manager" value="$(arg use_controller_manager)" />
+
  <rosparam file="$(find ur5_collision_avoidance_moveit_config)/config/controllers.yaml"/>
 </launch>

--- a/training/work/demo_manipulation/src/ur5_collision_avoidance_moveit_config/config/controllers.yaml
+++ b/training/work/demo_manipulation/src/ur5_collision_avoidance_moveit_config/config/controllers.yaml
@@ -1,8 +1,7 @@
-controller_manager_ns: pr2_controller_manager
 controller_list:
   - name: ""
-    ns: joint_trajectory_action
-    default: true
+    action_ns: joint_trajectory_action
+    type: FollowJointTrajectory
     joints:
       - elbow_joint
       - shoulder_lift_joint

--- a/training/work/demo_manipulation/src/ur5_collision_avoidance_moveit_config/launch/ur5_collision_avoidance_moveit_controller_manager.launch
+++ b/training/work/demo_manipulation/src/ur5_collision_avoidance_moveit_config/launch/ur5_collision_avoidance_moveit_controller_manager.launch
@@ -1,9 +1,6 @@
 <launch>
- <arg name="moveit_controller_manager" default="pr2_moveit_controller_manager/Pr2MoveItControllerManager" />
+ <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager" />
  <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
- <arg name="controller_manager_name" default="pr2_controller_manager" />
- <param name="controller_manager_name" value="$(arg controller_manager_name)" />
- <arg name="use_controller_manager" default="false" />
- <param name="use_controller_manager" value="$(arg use_controller_manager)" />
+
  <rosparam file="$(find ur5_collision_avoidance_moveit_config)/config/controllers.yaml"/>
 </launch>


### PR DESCRIPTION
this keeps us from needing to install `ros-indigo-moveit-desktop-full-pr2` in VM (existing `ros-indigo-moveit-desktop-full` is sufficient)