### PR TITLE
Addressing #79 - Descartes UR5 Model Adjustments

### DIFF
--- a/training/orig/demo_descartes/src/ur5_demo_descartes/include/ur5_demo_descartes/ur5_robot_model.h
+++ b/training/orig/demo_descartes/src/ur5_demo_descartes/include/ur5_demo_descartes/ur5_robot_model.h
@@ -34,6 +34,9 @@ public:
 
   virtual bool getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const;
 
+  virtual bool getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
+                     std::vector<double> &joint_pose) const;
+
   descartes_core::Frame world_to_base_;// world to arm base
   descartes_core::Frame tool_to_tip_; // from arm tool to robot tool
 

--- a/training/ref/demo_descartes/src/ur5_demo_descartes/include/ur5_demo_descartes/ur5_robot_model.h
+++ b/training/ref/demo_descartes/src/ur5_demo_descartes/include/ur5_demo_descartes/ur5_robot_model.h
@@ -34,6 +34,9 @@ public:
 
   virtual bool getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const;
 
+  virtual bool getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
+                     std::vector<double> &joint_pose) const;
+
   descartes_core::Frame world_to_base_;// world to arm base
   descartes_core::Frame tool_to_tip_; // from arm tool to robot tool
 

--- a/training/work/demo_descartes/src/ur5_demo_descartes/include/ur5_demo_descartes/ur5_robot_model.h
+++ b/training/work/demo_descartes/src/ur5_demo_descartes/include/ur5_demo_descartes/ur5_robot_model.h
@@ -34,6 +34,9 @@ public:
 
   virtual bool getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const;
 
+  virtual bool getIK(const Eigen::Affine3d &pose, const std::vector<double> &seed_state,
+                     std::vector<double> &joint_pose) const;
+
   descartes_core::Frame world_to_base_;// world to arm base
   descartes_core::Frame tool_to_tip_; // from arm tool to robot tool
 


### PR DESCRIPTION
This PR addresses #79. Adds `getIK()` to the overridden methods inside the Descartes robot model for the UR5. Previously calls to this function were being forwarded to MoveIt, leading to inconsistent IK results from any routines that rely on this method.