### PR TITLE
Minor fix to prevent error on shutdown

### DIFF
--- a/training/orig/2.2/src/lesson_actions/src/calcPi_server.cpp
+++ b/training/orig/2.2/src/lesson_actions/src/calcPi_server.cpp
@@ -60,6 +60,8 @@ int main(int argc, char** argv)
   ROS_INFO("CalcPi server started");
 
   ros::spin();
+  // cleaning up our global now prevents an error on process cleanup
+  as_.reset();
 
   return 0;
 }

--- a/training/ref/2.2/src/lesson_actions/src/calcPi_server.cpp
+++ b/training/ref/2.2/src/lesson_actions/src/calcPi_server.cpp
@@ -60,6 +60,8 @@ int main(int argc, char** argv)
   ROS_INFO("CalcPi server started");
 
   ros::spin();
+  // cleaning up our global now prevents an error on process cleanup
+  as_.reset();
 
   return 0;
 }

--- a/training/work/2.2/src/lesson_actions/src/calcPi_server.cpp
+++ b/training/work/2.2/src/lesson_actions/src/calcPi_server.cpp
@@ -60,6 +60,8 @@ int main(int argc, char** argv)
   ROS_INFO("CalcPi server started");
 
   ros::spin();
+  // cleaning up our global now prevents an error on process cleanup
+  as_.reset();
 
   return 0;
 }


### PR DESCRIPTION
This prevents the following error upon shutting down calcPi_server:

```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
  what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
Aborted (core dumped)
```