### PR TITLE
Use <exec_depend> instead of <run_depend>

### DIFF
--- a/gh_pages/_source/session1/Topics-and-Messages.md
+++ b/gh_pages/_source/session1/Topics-and-Messages.md
@@ -75,7 +75,7 @@ Your goal is to create your first ROS subscriber:
 
    ```xml
    <build_depend>fake_ar_publisher</build_depend>
-   <run_depend>fake_ar_publisher</run_depend>
+   <exec_depend>fake_ar_publisher</exec_depend>
    ```
 
 4. `cd` into your catkin workspace


### PR DESCRIPTION
Use <exec_depend> instead of <run_depend>, because it uses package format 2