### PR TITLE
Added exec_depend instead of run_depend

### DIFF
--- a/gh_pages/_source/session1/Topics-and-Messages.md
+++ b/gh_pages/_source/session1/Topics-and-Messages.md
@@ -75,7 +75,8 @@ Your goal is to create your first ROS subscriber:
 
    ```xml
    <build_depend>fake_ar_publisher</build_depend>
-   <run_depend>fake_ar_publisher</run_depend>
+   <!-- <run_depend>fake_ar_publisher</run_depend> -->
+   <exec_depend>fake_ar_publisher</exec_depend>
    ```
 
 4. `cd` into your catkin workspace


### PR DESCRIPTION
Made changes as a correction to the following error by using exec_depend.

Error message:  'The manifest (with format version 2) must not contain the following tags: run_depend'. 

Comments: Can we extend to this somehow to work for both version 1 and version 2 format manifests?