### PR TITLE
updated hyperlinks to new ros wiki source 

### DIFF
--- a/gh_pages/_source/demo1/Create-pick-moves.md
+++ b/gh_pages/_source/demo1/Create-pick-moves.md
@@ -63,4 +63,4 @@ z: 0.3
 
 [lookupTransform](http://mirror.umd.edu/roswiki/doc/hydro/api/tf/html/c++/classtf_1_1Transformer.html#ac01a9f8709a828c427f1a5faa0ced42b)
 
-[TF Transforms and other useful data types](http://www.ros.org/wiki/tf/Overview/Data%20Types)
+[TF Transforms and other useful data types](http://wiki.ros.org/tf/Overview/Data%20Types)

--- a/gh_pages/_source/demo1/Create-place-moves.md
+++ b/gh_pages/_source/demo1/Create-place-moves.md
@@ -62,4 +62,4 @@ z: 0.3
 
 [lookupTransform](http://mirror.umd.edu/roswiki/doc/hydro/api/tf/html/c++/classtf_1_1Transformer.html#ac01a9f8709a828c427f1a5faa0ced42b)
 
-[TF Transforms and other useful data types](http://www.ros.org/wiki/tf/Overview/Data%20Types)
+[TF Transforms and other useful data types](http://wiki.ros.org/tf/Overview/Data%20Types)

--- a/gh_pages/_source/session1/Creating-a-ROS-Package-and-Node.md
+++ b/gh_pages/_source/session1/Creating-a-ROS-Package-and-Node.md
@@ -5,12 +5,12 @@
 The basis of ROS communication is that multiple executables called nodes are running in an environment and communicating with each other in various ways. These nodes exist within a structure called a package. In this module we will create a node inside a newly created package.
 
 ## Reference Example
-[Create a Package](http://www.ros.org/wiki/ROS/Tutorials/CreatingPackage) 
+[Create a Package](http://wiki.ros.org/ROS/Tutorials/CreatingPackage) 
 
 ## Further Information and Resources
-[Building Packages](http://www.ros.org/wiki/ROS/Tutorials/BuildingPackages)
+[Building Packages](http://wiki.ros.org/ROS/Tutorials/BuildingPackages)
 
-[Understanding Nodes](http://www.ros.org/wiki/ROS/Tutorials/UnderstandingNodes)
+[Understanding Nodes](http://wiki.ros.org/ROS/Tutorials/UnderstandingNodes)
 
 ## Scan-N-Plan Application: Problem Statement
 We've installed ROS, created a workspace, and even built a few times. Now we want to create our own package and our own node to do what we want to do.

--- a/gh_pages/_source/session1/ROS-Setup.md
+++ b/gh_pages/_source/session1/ROS-Setup.md
@@ -6,10 +6,10 @@
 In order to start programming in ROS, you should know how to install ROS on a new machine as well and check that the installation worked properly. This module will walk you through a few simple checks of your installed ROS system. Assuming you are working from the VM, you can skip any installation instructions as ROS is already installed.
 
 ## Reference Example
-[Configuring ROS](http://www.ros.org/wiki/ROS/Tutorials/InstallingandConfiguringROSEnvironment)
+[Configuring ROS](http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment)
 
 ## Further Information and Resources
-[Installation Instructions](http://www.ros.org/wiki/kinetic/Installation/Ubuntu)
+[Installation Instructions](http://wiki.ros.org/kinetic/Installation/Ubuntu)
 
 [Navigating ROS](http://wiki.ros.org/ROS/Tutorials/NavigatingTheFilesystem)
 

--- a/gh_pages/_source/session1/Topics-and-Messages.md
+++ b/gh_pages/_source/session1/Topics-and-Messages.md
@@ -6,15 +6,15 @@ The first type of ROS communication that we will explore is a one-way communicat
 
 ## Reference Example
 
-[Create a Subscriber](http://www.ros.org/wiki/ROS/Tutorials/WritingPublisherSubscriber%28c%2B%2B%29)
+[Create a Subscriber](http://wiki.ros.org/ROS/Tutorials/WritingPublisherSubscriber%28c%2B%2B%29)
 
 ## Further Information and Resources
 
-[Understanding Topics](http://www.ros.org/wiki/ROS/Tutorials/UnderstandingTopics)
+[Understanding Topics](http://wiki.ros.org/ROS/Tutorials/UnderstandingTopics)
 
-[Examining Publisher & Subscriber](http://www.ros.org/wiki/ROS/Tutorials/ExaminingPublisherSubscriber)
+[Examining Publisher & Subscriber](http://wiki.ros.org/ROS/Tutorials/ExaminingPublisherSubscriber)
 
-[Creating Messages and Services](http://www.ros.org/wiki/ROS/Tutorials/CreatingMsgAndSrv)
+[Creating Messages and Services](http://wiki.ros.org/ROS/Tutorials/CreatingMsgAndSrv)
 
 ## Scan-N-Plan Application: Problem Statement
 We now have a base ROS node and we want to build on this node. Now we want to create a subscriber within our node.

--- a/gh_pages/_source/session2/Actions.md
+++ b/gh_pages/_source/session2/Actions.md
@@ -4,6 +4,6 @@
 ***
 
 ## ROS Tutorials for C++ Action Client/Server usage
- * [SimpleActionServer](http://www.ros.org/wiki/actionlib_tutorials/Tutorials/SimpleActionServer%28ExecuteCallbackMethod%29)
+ * [SimpleActionServer](http://wiki.ros.org/actionlib_tutorials/Tutorials/SimpleActionServer%28ExecuteCallbackMethod%29)
 
- * [SimpleActionClient](http://www.ros.org/wiki/actionlib_tutorials/Tutorials/SimpleActionClient)
+ * [SimpleActionClient](http://wiki.ros.org/actionlib_tutorials/Tutorials/SimpleActionClient)

--- a/gh_pages/_source/session2/Parameters.md
+++ b/gh_pages/_source/session2/Parameters.md
@@ -7,14 +7,14 @@ By this point in these tutorials (or your career), you've probably typed the wor
 The ROS ecosystem has an analogous system for configuring entire groups of nodes. It's a fancy key-value storage program that gets brought up as part of `roscore`. It's best used to pass configuration parameters to nodes individually (e.g. to identify which camera a node should subscribe to), but it can be used for much more complicated items.
 
 ## Reference Example
-[Understanding Parameters](http://www.ros.org/wiki/ROS/Tutorials/UnderstandingServicesParams#Using_rosparam)
+[Understanding Parameters](http://wiki.ros.org/ROS/Tutorials/UnderstandingServicesParams#Using_rosparam)
 
 ## Further Information and Resource
-[Roscpp tutorial](http://www.ros.org/wiki/roscpp_tutorials/Tutorials/Parameters)
+[Roscpp tutorial](http://wiki.ros.org/roscpp_tutorials/Tutorials/Parameters)
 
-[Private Parameters](http://www.ros.org/wiki/roscpp_tutorials/Tutorials/AccessingPrivateNamesWithNodeHandle)
+[Private Parameters](http://wiki.ros.org/roscpp_tutorials/Tutorials/AccessingPrivateNamesWithNodeHandle)
 
-[Parameter Server](http://www.ros.org/wiki/Parameter%20Server)
+[Parameter Server](http://wiki.ros.org/Parameter%20Server)
 
 
 ## Scan-N-Plan Application: Problem Statement
@@ -41,7 +41,7 @@ So far we haven't used the request field, `base_frame`, for anything. In this ex
 
 1. Open up `myworkcell_node.cpp` for editing.
 
-2. Add a new `ros::NodeHandle` object to the `main` function, and make it private through its parameters. For more guidance, see the [ros wiki](http://www.ros.org/wiki/roscpp_tutorials/Tutorials/AccessingPrivateNamesWithNodeHandle) on this subject.
+2. Add a new `ros::NodeHandle` object to the `main` function, and make it private through its parameters. For more guidance, see the [ros wiki](http://wiki.ros.org/roscpp_tutorials/Tutorials/AccessingPrivateNamesWithNodeHandle) on this subject.
 
    ``` c++
    ros::NodeHandle private_node_handle ("~");


### PR DESCRIPTION
Related to issue 163: https://github.com/ros-industrial/industrial_training/issues/163

Updated relevant hyperlinks to the new wiki source (i.e from http://www.ros.org/wiki/ROS/../.. to http://wiki.ros.org/ROS/../..).

"edit": I checked each of the modified hyperlinks after changing and they all work. 