### PR TITLE
Added a note regarding naming the planning group

### DIFF
--- a/gh_pages/_source/session3/Build-a-Moveit!-Package.md
+++ b/gh_pages/_source/session3/Build-a-Moveit!-Package.md
@@ -41,7 +41,7 @@ In this exercise, you will generate a MoveIt package for the UR5 workcell you bu
        type = 'fixed'
        ```
 
-    1. Add a planning group called `manipulator` that names the kinematic chain between `base_link` and `tool0`. Note: Make sure there are no spaces after the planning group name. 
+    1. Add a planning group called `manipulator` that names the kinematic chain between `base_link` and `tool0`. Note: Follow [ROS naming guidelines/requirements](http://wiki.ros.org/ROS/Patterns/Conventions) and don't use any whitespace, anywhere. 
 
        a. Set the kinematics solver to `KDLKinematicsPlugin`
 

--- a/gh_pages/_source/session3/Build-a-Moveit!-Package.md
+++ b/gh_pages/_source/session3/Build-a-Moveit!-Package.md
@@ -41,7 +41,7 @@ In this exercise, you will generate a MoveIt package for the UR5 workcell you bu
        type = 'fixed'
        ```
 
-    1. Add a planning group called `manipulator` that names the kinematic chain between `base_link` and `tool0`.
+    1. Add a planning group called `manipulator` that names the kinematic chain between `base_link` and `tool0`. Note: Make sure there are no spaces after the planning group name. 
 
        a. Set the kinematics solver to `KDLKinematicsPlugin`
 


### PR DESCRIPTION
As per this [ROS Answers Question](https://answers.ros.org/question/290983/error-in-planning-group-with-moveit-setup-assistant/), adding a space at the end of planning group name may lead to the "manipulator" group key word to be not detected for adding poses and end-effectors. Hence, updated the documentation to alert newbies like me.