### PR TITLE
Set pose reference frame in myworkcell_node

### DIFF
--- a/exercises/4.0/src/myworkcell_core/src/myworkcell_node.cpp
+++ b/exercises/4.0/src/myworkcell_core/src/myworkcell_node.cpp
@@ -31,6 +31,7 @@ public:
     // Plan for robot to move to part
     moveit::planning_interface::MoveGroupInterface move_group("manipulator");
     geometry_msgs::Pose move_target = srv.response.pose;
+    move_group.setPoseReferenceFrame(base_frame);
     move_group.setPoseTarget(move_target);
     move_group.move();
   }

--- a/gh_pages/_source/session4/Motion-Planning-CPP.md
+++ b/gh_pages/_source/session4/Motion-Planning-CPP.md
@@ -51,7 +51,8 @@ In this exercise, your goal is to modify the `myworkcell_core` node to:
     1. Set the desired cartesian target position using the `move_group` object’s `setPoseTarget` function. Call the object's `move()` function to plan and execute a move to the target position.
 
        ```c++
-       // Plan for robot to move to part     
+       // Plan for robot to move to part
+       move_group.setPoseReferenceFrame(base_frame);
        move_group.setPoseTarget(move_target); 
        move_group.move();
        ```


### PR DESCRIPTION
The `MoveGroupInterface::setPoseTarget` method assumes the input frame is the root frame of the TF tree unless otherwise specified. If the `base_frame` parameter is a frame that exists in TF but isn't the root of the TF tree, the robot will move to the wrong place. Calling `MoveGroupInterface::setPoseReferenceFrame` with the correct base frame name resolves this issue.