### PR TITLE
Permanent URL added to the file #wrid18 #ROSIndia

### DIFF
--- a/gh_pages/_source/session3/Intro-to-URDF.md
+++ b/gh_pages/_source/session3/Intro-to-URDF.md
@@ -38,7 +38,7 @@ Your goal is to describe a workcell that features:
    </robot>
    ```
 
-1. Add the required links. See the [irb2400_macro.xacro](https://github.com/ros-industrial/abb/blob/indigo-devel/abb_irb2400_support/urdf/irb2400_macro.xacro#L56-L71) example from an ABB2400.
+1. Add the required links. See the [irb2400_macro.xacro](https://github.com/ros-industrial/abb/blob/84825661073a18e33b68bb01b5bf371edd2efd49/abb_irb2400_support/urdf/irb2400_macro.xacro#L56-L71) example from an ABB2400.
 
    1. Add the `world` frame as a "virtual link" (no geometry).
 


### PR DESCRIPTION
Reference [#175](https://github.com/ros-industrial/industrial_training/issues/175)
added permanent URL to the Github link,
and all the other files in source of gh_pages are repository links and i dont think they require permanent url