### PR TITLE
Update Perception-Driven Manipulation Demo Documentation

### DIFF
--- a/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/include/plan_and_run/demo_application.h
+++ b/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/include/plan_and_run/demo_application.h
@@ -87,7 +87,7 @@ public:
 
   /* Main Application Functions
    *  Functions that allow carrying out the various steps needed to run a
-   *  plan an run application.  All these functions will be invoked from within
+   *  plan and run application.  All these functions will be invoked from within
    *  the main routine.
    */
 

--- a/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/src/tasks/load_parameters.cpp
+++ b/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/src/tasks/load_parameters.cpp
@@ -3,7 +3,7 @@
 
 /* LOAD PARAMETERS
   Goal:
-    - Load missing application parameters into the from the ros parameter server.
+    - Load missing application parameters from the ros parameter server.
     - Use a private NodeHandle in order to load parameters defined in the node's namespace.
 
   Hints:

--- a/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/include/plan_and_run/demo_application.h
+++ b/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/include/plan_and_run/demo_application.h
@@ -87,7 +87,7 @@ public:
 
   /* Main Application Functions
    *  Functions that allow carrying out the various steps needed to run a
-   *  plan an run application.  All these functions will be invoked from within
+   *  plan and run application.  All these functions will be invoked from within
    *  the main routine.
    */
 

--- a/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/src/tasks/load_parameters.cpp
+++ b/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/src/tasks/load_parameters.cpp
@@ -3,7 +3,7 @@
 
 /* LOAD PARAMETERS
   Goal:
-    - Load missing application parameters into the from the ros parameter server.
+    - Load missing application parameters from the ros parameter server.
     - Use a private NodeHandle in order to load parameters defined in the node's namespace.
 
   Hints:

--- a/gh_pages/_source/demo1/Inspect-the-package.md
+++ b/gh_pages/_source/demo1/Inspect-the-package.md
@@ -9,13 +9,6 @@ source /opt/ros/kinetic/setup.bash
 catkin init
 ```
 
-## Download source dependencies
->Use the [wstool](http://wiki.ros.org/wstool) command to download the repositories listed in the `src/.rosinstall` file
-```
-cd ~/perception_driven_ws/src/
-wstool update
-```
-
 ## Download debian dependencies
 >Make sure you have installed and configured the [rosdep tool](http://wiki.ros.org/rosdep).
 >Then, run the following command from the `src` directory of your workspace.

--- a/gh_pages/_source/demo2/Application-Structure.md
+++ b/gh_pages/_source/demo2/Application-Structure.md
@@ -112,7 +112,7 @@ int main(int argc,char** argv)
 }
 ```
 
-  In short, this program will run through each exercise by calling the corresponding function from the `application` object.  For instance, in order to initialize Descartes the program calls `application.iniDescartes()`.  Thus each exercise consists of editing the source file where that exercise is implemented, so for `application.initDescartes()` you'll be editing the `plan_and_run/src/tasks/init_descartes.src` source file.
+  In short, this program will run through each exercise by calling the corresponding function from the `application` object.  For instance, in order to initialize Descartes the program calls `application.initDescartes()`.  Thus each exercise consists of editing the source file where that exercise is implemented, so for `application.initDescartes()` you'll be editing the `plan_and_run/src/tasks/init_descartes.src` source file.
 
 
 ## The DemoApplication Class
@@ -186,7 +186,7 @@ public:
 
   /* Main Application Functions
    *  Functions that allow carrying out the various steps needed to run a
-   *  plan an run application.  All these functions will be invoked from within
+   *  plan and run application.  All these functions will be invoked from within
    *  the main routine.
    */
 
@@ -271,6 +271,6 @@ protected:
   * tip_link: Name of the last link in the kinematic chain, usually the tool link.
   * base_link: Name for the base link of the robot.
   * world_frame: The absolute coordinate frame of reference for all the objects defined in the planning environment.
- * The parameters under the "`trajectory`" namespace are used to generate the trajectory that is feed into the Descartes planner.
+ * The parameters under the "`trajectory`" namespace are used to generate the trajectory that is fed into the Descartes planner.
   * trajectory/seed_pose: This is of particular importance because it is used to indicate preferred start and end joint configurations of the robot when planning the path.  If a ''seed_pose'' wasn't specified then planning would take longer since multiple start and end joint configurations would have to be taken into account, leading to multiple path solutions that result from combining several start and end poses. 
  

--- a/gh_pages/_source/demo2/Plan-a-robot-path.md
+++ b/gh_pages/_source/demo2/Plan-a-robot-path.md
@@ -10,7 +10,7 @@
 
 ## Complete Code
 
- * Observe the use of the [AxialSymmetricPt::getClosesJointPose()](http://docs.ros.org/indigo/api/descartes_trajectory/html/classdescartes__trajectory_1_1CartTrajectoryPt.html#a1252c8f49a6e5a7d563b6d4a256b553b) in order to get the joint values of the robot that is closest to an arbitrary joint pose.  Furthermore, this step allows us to select a single joint pose for the start and end rather than multiple valid joint configurations.
+ * Observe the use of the [AxialSymmetricPt::getClosestJointPose()](http://docs.ros.org/indigo/api/descartes_trajectory/html/classdescartes__trajectory_1_1CartTrajectoryPt.html#a1252c8f49a6e5a7d563b6d4a256b553b) in order to get the joint values of the robot that is closest to an arbitrary joint pose.  Furthermore, this step allows us to select a single joint pose for the start and end rather than multiple valid joint configurations.
  * Call the [DensePlanner::planPath()](http://docs.ros.org/indigo/api/descartes_planner/html/classdescartes__planner_1_1DensePlanner.html#a2181f674af57b92023deabb5e8323a2a) method in order to compute a motion plan.
  * When planning succeeds, use the [DensePlanner::getPath()](http://docs.ros.org/indigo/api/descartes_planner/html/classdescartes__planner_1_1DensePlanner.html#aafd40b5dc5ed39b4f10e9b47fda0419f) method in order to retrieve the path from the planner and save it into the `output_path` variable.
  * Find comment block that starts with `/*  Fill Code:` and complete as described.


### PR DESCRIPTION
Removed "Download Source Dependencies" section from documentation. .rosinstall was removed in commit <2296f3d9193c7fbcc829aa361660168ecca9001e> because all packages are now available from apt, but the documentation still referenced the file.