### PR TITLE
Exercise 3.2 Documentation Update

### DIFF
--- a/gh_pages/_source/session3/Coordinate-Transforms-using-TF.md
+++ b/gh_pages/_source/session3/Coordinate-Transforms-using-TF.md
@@ -36,6 +36,12 @@ Specifically, edit the service callback inside the vision_node to transform the 
 
  1. Add code to the existing `localizePart` method to convert the reported target pose from its reference frame ("camera_frame") to the service-request frame:
 
+    1. Remove the placeholder line from a previous exercise that sets the resulting pose equal to the pose from the last message
+
+       ``` diff
+       - res.pose = p->pose.pose;
+       ```
+
     1. For better or worse, ROS uses lots of different math libraries. You’ll need to transform the over-the-wire format of `geometry_msgs::Pose` into a `tf::Transform object`:
 
        ``` c++


### PR DESCRIPTION
This PR adds a reminder in the exercise 3.2 documentation to remove placeholder code added in exercise 2.0 which sets the result pose of the `localizePart` service equal to the pose of the last incoming message. 

I've seen issues on a couple of occasions where people keep this placeholder line at the end of the function and end up overwriting all of the transformation code they just implemented, causing the localization to be incorrect