### PR TITLE
Fix reference to renamed documentation page

### DIFF
--- a/gh_pages/index.rst
+++ b/gh_pages/index.rst
@@ -12,7 +12,7 @@ Setup PC
 .. toctree::
    :maxdepth: 1
 
-   PC Setup <_source/setup/PC-Setup---ROS-Melodic.md>
+   PC Setup <_source/setup/PC-Setup---ROS.md>
 
 Prerequisites
 -------------


### PR DESCRIPTION
The PC setup page was renamed in #242 but the index was not updated accordingly. 