### PR TITLE
Changing the documention text to mention melodic instead of kinetic for or demo3 Read the Docs

### DIFF
--- a/gh_pages/_source/demo3/Inspect-the-package.md
+++ b/gh_pages/_source/demo3/Inspect-the-package.md
@@ -5,7 +5,7 @@ In this exercise, we will get familiar with all the files that you'll be interac
 ```
 cp -r ~/industrial_training/exercises/Optimization_Based_Planning/template_ws ~/optimized_planning_ws
 cd ~/optimized_planning_ws
-source /opt/ros/kinetic/setup.bash
+source /opt/ros/melodic/setup.bash
 catkin init
 ```
 

--- a/gh_pages/_source/demo3/Package-Setup.md
+++ b/gh_pages/_source/demo3/Package-Setup.md
@@ -10,7 +10,7 @@ File -> New -> Other Project -> ROS Workspace
 2) Fill the Project Name and Location information
 
 * Name:  ```pick_and_place```
-* Distribution: ``kinetic```
+* Distribution: ```melodic```
 * Build System: ```CatkinTools```
 * Workspace Path ```~/optimized_planning_ws```
 


### PR DESCRIPTION
When demo3 was initially made, the original intention was to be used in Kinetic. This change on Read the Docs eliminates references to Kinetic (and changes references to Melodic) for sections simulating the Kuka robot.