### PR TITLE
No longer necessary to append/rename planners

### DIFF
--- a/gh_pages/_source/session3/Build-a-Moveit!-Package.md
+++ b/gh_pages/_source/session3/Build-a-Moveit!-Package.md
@@ -54,11 +54,6 @@ In this exercise, you will generate a MoveIt package for the UR5 workcell you bu
     1. Generate a new package and name it `myworkcell_moveit_config`.
        * make sure to create the package inside your `catkin_ws/src` directory
 
-    1. The current MoveIt! Settup Assistant has a [bug](https://github.com/ros-planning/moveit/issues/955) that causes some minor errors and abnormal behaviors.  To fix these errors:
-       1. Edit the `myworkcell_core_moveit_config/config/ompl_planning.yaml` file.
-       1. Append the text string `kConfigDefault` to each planner name
-          * e.g. `SBL:` -> `SBLkConfigDefault`, etc.
-
  The outcome of these steps will be a new package that contains a large number of launch and configuration files. At this point, it's possible to do motion planning, but not to execute the plan on any robot.  To try out your new configuration:
 
     catkin build


### PR DESCRIPTION
The MoveIt bug seems to no longer be a problem, and adding this extensions throws errors.