### PR TITLE
[Perception-Driven_Manipulation] Fixed controller and compilation error. 

### DIFF
--- a/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/src/demo_application.cpp
+++ b/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/src/demo_application.cpp
@@ -202,9 +202,10 @@ bool DemoApplication::createLemniscateCurve(double foci_distance, double sphere_
       unit_y = (unit_z .cross(unit_x)).normalized();
 
       Eigen::Isometry3d rot;
-      rot.matrix() << unit_x(0),unit_y(0),unit_z(0)
-         ,unit_x(1),unit_y(1),unit_z(1)
-         ,unit_x(2),unit_y(2),unit_z(2);
+      rot.matrix() << unit_x(0),unit_y(0),unit_z(0),0
+         ,unit_x(1),unit_y(1),unit_z(1),0
+         ,unit_x(2),unit_y(2),unit_z(2),0
+         ,0,0,0,0;
 
 
 

--- a/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/src/demo_application.cpp
+++ b/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/src/demo_application.cpp
@@ -202,9 +202,10 @@ bool DemoApplication::createLemniscateCurve(double foci_distance, double sphere_
       unit_y = (unit_z .cross(unit_x)).normalized();
 
       Eigen::Isometry3d rot;
-      rot.matrix() << unit_x(0),unit_y(0),unit_z(0)
-         ,unit_x(1),unit_y(1),unit_z(1)
-         ,unit_x(2),unit_y(2),unit_z(2);
+      rot.matrix() << unit_x(0),unit_y(0),unit_z(0),0
+         ,unit_x(1),unit_y(1),unit_z(1),0
+         ,unit_x(2),unit_y(2),unit_z(2),0
+         ,0,0,0,0;
 
       pose = Eigen::Translation3d(offset(0) + x,
                                   offset(1) + y,

--- a/exercises/Perception-Driven_Manipulation/solution_ws/src/collision_avoidance_pick_and_place/src/tasks/set_attached_object.cpp
+++ b/exercises/Perception-Driven_Manipulation/solution_ws/src/collision_avoidance_pick_and_place/src/tasks/set_attached_object.cpp
@@ -27,7 +27,7 @@ void PickAndPlace::set_attached_object(bool attach, const geometry_msgs::Pose &p
     // constructing pose
     tf::Transform attached_tf;
     tf::poseMsgToTF(cfg.ATTACHED_OBJECT.primitive_poses[0],attached_tf);
-    EigenSTL::vector_Affine3d pose_array(1);
+    EigenSTL::vector_Isometry3d pose_array(1);
     tf::transformTFToEigen(attached_tf,pose_array[0]);
 
     // attaching

--- a/exercises/Perception-Driven_Manipulation/solution_ws/src/robot_config/urdf/ur5.urdf.xacro
+++ b/exercises/Perception-Driven_Manipulation/solution_ws/src/robot_config/urdf/ur5.urdf.xacro
@@ -310,7 +310,7 @@
       </collision>
     </link>
 
-    <xacro:ur_arm_transmission prefix="${prefix}" />
+    <xacro:ur_arm_transmission prefix="${prefix}" hw_interface="" />
     <xacro:ur_arm_gazebo prefix="${prefix}" />
 
   </xacro:macro>

--- a/exercises/Perception-Driven_Manipulation/solution_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
+++ b/exercises/Perception-Driven_Manipulation/solution_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
@@ -14,7 +14,11 @@
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
+  
+  <param name="move_group/trajectory_execution/allowed_execution_duration_scaling" value="4.0"/>
+  <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
 
+	
   <include ns="move_group" file="$(find ur5_collision_avoidance_moveit_config)/launch/planning_pipeline.launch">
     <arg name="pipeline" value="ompl" />
   </include>

--- a/exercises/Perception-Driven_Manipulation/template_ws/src/collision_avoidance_pick_and_place/src/tasks/set_attached_object.cpp
+++ b/exercises/Perception-Driven_Manipulation/template_ws/src/collision_avoidance_pick_and_place/src/tasks/set_attached_object.cpp
@@ -27,7 +27,7 @@ void PickAndPlace::set_attached_object(bool attach, const geometry_msgs::Pose &p
     // constructing pose
     tf::Transform attached_tf;
     tf::poseMsgToTF(cfg.ATTACHED_OBJECT.primitive_poses[0],attached_tf);
-    EigenSTL::vector_Affine3d pose_array(1);
+    EigenSTL::vector_Isometry3d pose_array(1);
     tf::transformTFToEigen(attached_tf,pose_array[0]);
 
     // attaching

--- a/exercises/Perception-Driven_Manipulation/template_ws/src/robot_config/urdf/ur5.urdf.xacro
+++ b/exercises/Perception-Driven_Manipulation/template_ws/src/robot_config/urdf/ur5.urdf.xacro
@@ -310,7 +310,7 @@
       </collision>
     </link>
 
-    <xacro:ur_arm_transmission prefix="${prefix}" />
+    <xacro:ur_arm_transmission prefix="${prefix}" hw_interface="" />
     <xacro:ur_arm_gazebo prefix="${prefix}" />
 
   </xacro:macro>

--- a/exercises/Perception-Driven_Manipulation/template_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
+++ b/exercises/Perception-Driven_Manipulation/template_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
@@ -14,6 +14,9 @@
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
+	
+  <param name="move_group/trajectory_execution/allowed_execution_duration_scaling" value="4.0"/>
+  <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
 
   <include ns="move_group" file="$(find ur5_collision_avoidance_moveit_config)/launch/planning_pipeline.launch">
     <arg name="pipeline" value="ompl" />


### PR DESCRIPTION
1. Added `allowed_execution_duration_scaling` and `execution_duration_monitoring` to bypass controller time out error. User may scale the value to increase the buffer for controller time out error. 

2. Changed `Affine3d` to `Isometry3d` to skip compilation error.