### PR TITLE
[Perception-Driven_Manipulation] Fixed controller time out issue.

### DIFF
--- a/exercises/3.3/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
+++ b/exercises/3.3/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
@@ -37,6 +37,7 @@
       <arg name="min_payload" value="0.0"/>
       <arg name="max_payload" value="5.0"/>
     </include>
+    <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
   </group>
 
   <include file="$(find myworkcell_moveit_config)/launch/move_group.launch">

--- a/exercises/4.0/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
+++ b/exercises/4.0/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
@@ -37,6 +37,7 @@
       <arg name="min_payload" value="0.0"/>
       <arg name="max_payload" value="5.0"/>
     </include>
+    <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
   </group>
 
   <include file="$(find myworkcell_moveit_config)/launch/move_group.launch">

--- a/exercises/4.1/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
+++ b/exercises/4.1/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
@@ -37,6 +37,7 @@
       <arg name="min_payload" value="0.0"/>
       <arg name="max_payload" value="5.0"/>
     </include>
+    <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
   </group>
 
   <include file="$(find myworkcell_moveit_config)/launch/move_group.launch">

--- a/exercises/5.0/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
+++ b/exercises/5.0/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
@@ -37,6 +37,7 @@
       <arg name="min_payload" value="0.0"/>
       <arg name="max_payload" value="5.0"/>
     </include>
+    <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
   </group>
 
   <include file="$(find myworkcell_moveit_config)/launch/move_group.launch">

--- a/exercises/6.0/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
+++ b/exercises/6.0/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
@@ -37,6 +37,7 @@
       <arg name="min_payload" value="0.0"/>
       <arg name="max_payload" value="5.0"/>
     </include>
+    <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
   </group>
 
   <include file="$(find myworkcell_moveit_config)/launch/move_group.launch">

--- a/exercises/6.1/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
+++ b/exercises/6.1/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
@@ -37,6 +37,7 @@
       <arg name="min_payload" value="0.0"/>
       <arg name="max_payload" value="5.0"/>
     </include>
+    <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
   </group>
 
   <include file="$(find myworkcell_moveit_config)/launch/move_group.launch">

--- a/exercises/6.3/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
+++ b/exercises/6.3/src/myworkcell_moveit_config/launch/myworkcell_planning_execution.launch
@@ -37,6 +37,7 @@
       <arg name="min_payload" value="0.0"/>
       <arg name="max_payload" value="5.0"/>
     </include>
+    <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
   </group>
 
   <include file="$(find myworkcell_moveit_config)/launch/move_group.launch">

--- a/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/launch/demo_setup.launch
+++ b/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/launch/demo_setup.launch
@@ -56,6 +56,8 @@
       <arg name="max_payload" value="$(arg max_payload)" />
     </include>  
     
+    <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
+
     <!-- TF Buffer Server -->
     <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server" output="screen">
       <param name="buffer_size" value="120.0"/>

--- a/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/launch/demo_setup.launch
+++ b/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/launch/demo_setup.launch
@@ -56,6 +56,8 @@
       <arg name="max_payload" value="$(arg max_payload)" />
     </include>  
     
+    <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
+
     <!-- TF Buffer Server -->
     <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server" output="screen">
       <param name="buffer_size" value="120.0"/>

--- a/exercises/Perception-Driven_Manipulation/solution_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
+++ b/exercises/Perception-Driven_Manipulation/solution_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
@@ -15,9 +15,6 @@
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
 
-  <param name="move_group/trajectory_execution/allowed_execution_duration_scaling" value="4.0"/>
-  <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
-	
   <include ns="move_group" file="$(find ur5_collision_avoidance_moveit_config)/launch/planning_pipeline.launch">
     <arg name="pipeline" value="ompl" />
   </include>

--- a/exercises/Perception-Driven_Manipulation/solution_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
+++ b/exercises/Perception-Driven_Manipulation/solution_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
@@ -15,6 +15,9 @@
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
 
+  <param name="move_group/trajectory_execution/allowed_execution_duration_scaling" value="4.0"/>
+  <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
+	
   <include ns="move_group" file="$(find ur5_collision_avoidance_moveit_config)/launch/planning_pipeline.launch">
     <arg name="pipeline" value="ompl" />
   </include>

--- a/exercises/Perception-Driven_Manipulation/solution_ws/src/ur5_collision_avoidance_moveit_config/launch/moveit_planning_execution.launch
+++ b/exercises/Perception-Driven_Manipulation/solution_ws/src/ur5_collision_avoidance_moveit_config/launch/moveit_planning_execution.launch
@@ -29,7 +29,7 @@
   <!--   - this typically includes: robot_state, motion_interface, and joint_trajectory_action nodes -->
   <!--   - replace these calls with appropriate robot-specific calls or launch files -->
   <group unless="$(arg sim)">
-	  <remap from="/follow_joint_trajectory/status" to="/joint_trajectory_action/status" />
+    <remap from="/follow_joint_trajectory/status" to="/joint_trajectory_action/status" />
     <remap from="/follow_joint_trajectory/feedback" to="/joint_trajectory_action/feedback" />
     <remap from="/follow_joint_trajectory/result" to="/joint_trajectory_action/result" />
     <remap from="/follow_joint_trajectory/goal" to="/joint_trajectory_action/goal" />
@@ -42,8 +42,8 @@
       <arg name="max_payload" value="$(arg max_payload)" />
     </include>  
 
+    <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
   </group>
-
 
   <rosparam command="load" file="$(find ur5_collision_avoidance_moveit_config)/config/joint_names.yaml"/>
 </launch>

--- a/exercises/Perception-Driven_Manipulation/template_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
+++ b/exercises/Perception-Driven_Manipulation/template_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
@@ -14,9 +14,6 @@
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
-  
-  <param name="move_group/trajectory_execution/allowed_execution_duration_scaling" value="4.0"/>
-  <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
 	
   <include ns="move_group" file="$(find ur5_collision_avoidance_moveit_config)/launch/planning_pipeline.launch">
     <arg name="pipeline" value="ompl" />

--- a/exercises/Perception-Driven_Manipulation/template_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
+++ b/exercises/Perception-Driven_Manipulation/template_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
@@ -14,7 +14,10 @@
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
-
+  
+  <param name="move_group/trajectory_execution/allowed_execution_duration_scaling" value="4.0"/>
+  <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
+	
   <include ns="move_group" file="$(find ur5_collision_avoidance_moveit_config)/launch/planning_pipeline.launch">
     <arg name="pipeline" value="ompl" />
   </include>

--- a/exercises/Perception-Driven_Manipulation/template_ws/src/ur5_collision_avoidance_moveit_config/launch/moveit_planning_execution.launch
+++ b/exercises/Perception-Driven_Manipulation/template_ws/src/ur5_collision_avoidance_moveit_config/launch/moveit_planning_execution.launch
@@ -42,6 +42,7 @@
       <arg name="max_payload" value="$(arg max_payload)" />
     </include>  
 
+    <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
   </group>
 
 


### PR DESCRIPTION
Added `allowed_execution_duration_scaling` and `execution_duration_monitoring` to bypass controller time out error. User may scale the value to increase the buffer for controller time out error.

