### PR TITLE
[Descartes_Planning_and_Execution] Fixed Eigen matrix initialization error 

### DIFF
--- a/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/src/demo_application.cpp
+++ b/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/src/demo_application.cpp
@@ -202,9 +202,10 @@ bool DemoApplication::createLemniscateCurve(double foci_distance, double sphere_
       unit_y = (unit_z .cross(unit_x)).normalized();
 
       Eigen::Isometry3d rot;
-      rot.matrix() << unit_x(0),unit_y(0),unit_z(0)
-         ,unit_x(1),unit_y(1),unit_z(1)
-         ,unit_x(2),unit_y(2),unit_z(2);
+      rot.matrix() << unit_x(0),unit_y(0),unit_z(0),0
+         ,unit_x(1),unit_y(1),unit_z(1),0
+         ,unit_x(2),unit_y(2),unit_z(2),0
+         ,0,0,0,0;
 
 
 

--- a/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/src/demo_application.cpp
+++ b/exercises/Descartes_Planning_and_Execution/solution_ws/src/plan_and_run/src/demo_application.cpp
@@ -205,7 +205,7 @@ bool DemoApplication::createLemniscateCurve(double foci_distance, double sphere_
       rot.matrix() << unit_x(0),unit_y(0),unit_z(0),0
          ,unit_x(1),unit_y(1),unit_z(1),0
          ,unit_x(2),unit_y(2),unit_z(2),0
-         ,0,0,0,0;
+         ,0,0,0,1;
 
 
 

--- a/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/src/demo_application.cpp
+++ b/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/src/demo_application.cpp
@@ -205,7 +205,7 @@ bool DemoApplication::createLemniscateCurve(double foci_distance, double sphere_
       rot.matrix() << unit_x(0),unit_y(0),unit_z(0),0
          ,unit_x(1),unit_y(1),unit_z(1),0
          ,unit_x(2),unit_y(2),unit_z(2),0
-         ,0,0,0,0;
+         ,0,0,0,1;
 
       pose = Eigen::Translation3d(offset(0) + x,
                                   offset(1) + y,

--- a/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/src/demo_application.cpp
+++ b/exercises/Descartes_Planning_and_Execution/template_ws/src/plan_and_run/src/demo_application.cpp
@@ -202,9 +202,10 @@ bool DemoApplication::createLemniscateCurve(double foci_distance, double sphere_
       unit_y = (unit_z .cross(unit_x)).normalized();
 
       Eigen::Isometry3d rot;
-      rot.matrix() << unit_x(0),unit_y(0),unit_z(0)
-         ,unit_x(1),unit_y(1),unit_z(1)
-         ,unit_x(2),unit_y(2),unit_z(2);
+      rot.matrix() << unit_x(0),unit_y(0),unit_z(0),0
+         ,unit_x(1),unit_y(1),unit_z(1),0
+         ,unit_x(2),unit_y(2),unit_z(2),0
+         ,0,0,0,0;
 
       pose = Eigen::Translation3d(offset(0) + x,
                                   offset(1) + y,


### PR DESCRIPTION
Changed the matrix for `rot` from 3x3 to 4x4 to overcome **Eigen Initialization Error**.