### PR TITLE
[Perception-Driven_Manipulation] Fixed the error of missing node file: mongo_wrapper_ros.py

### DIFF
--- a/exercises/Perception-Driven_Manipulation/solution_ws/src/collision_avoidance_pick_and_place/launch/ur5_pick_and_place.launch
+++ b/exercises/Perception-Driven_Manipulation/solution_ws/src/collision_avoidance_pick_and_place/launch/ur5_pick_and_place.launch
@@ -12,6 +12,4 @@
 
   <rosparam command="load" file="$(find ur5_collision_avoidance_moveit_config)/config/joint_names.yaml"/>
 
-  <include file="$(find ur5_collision_avoidance_moveit_config)/launch/default_warehouse_db.launch" />
-
 </launch>

--- a/exercises/Perception-Driven_Manipulation/template_ws/src/collision_avoidance_pick_and_place/launch/ur5_pick_and_place.launch
+++ b/exercises/Perception-Driven_Manipulation/template_ws/src/collision_avoidance_pick_and_place/launch/ur5_pick_and_place.launch
@@ -12,6 +12,4 @@
 
   <rosparam command="load" file="$(find ur5_collision_avoidance_moveit_config)/config/joint_names.yaml"/>
 
-  <include file="$(find ur5_collision_avoidance_moveit_config)/launch/default_warehouse_db.launch" />
-
 </launch>


### PR DESCRIPTION
Removed the line which included the launch file `default_warehouse_db.launch`. The launch file is not required for the Demo. 