### PR TITLE
Corrected 2 documentation errors in Exercise 3.3 and 5.4  

### DIFF
--- a/gh_pages/_source/session3/Build-a-Moveit!-Package.md
+++ b/gh_pages/_source/session3/Build-a-Moveit!-Package.md
@@ -39,7 +39,7 @@ In this exercise, you will generate a MoveIt package for the UR5 workcell you bu
        type = 'fixed'
        ```
 
-    1. Add a planning group called `manipulator` that names the kinematic chain between `base_link` and `tool0`. Note: Follow [ROS naming guidelines/requirements](http://wiki.ros.org/ROS/Patterns/Conventions) and don't use any whitespace, anywhere. 
+    1. Add a planning group called `manipulator` that names the kinematic chain between `base_link` and `tool0`. Note: Follow [ROS naming guidelines/requirements](http://wiki.ros.org/ROS/Patterns/Conventions) and don't use any whitespace, anywhere.
 
        a. Set the kinematics solver to `KDLKinematicsPlugin`
 
@@ -104,7 +104,7 @@ To do this, we need to define a few extra files.
     ```
 
  1. Create a new `myworkcell_planning_execution.launch` (in `myworkcell_moveit_config/launch`):
- 
+
     ``` xml
     <launch>
       <!-- The planning and execution components of MoveIt! configured to run -->
@@ -116,12 +116,12 @@ To do this, we need to define a few extra files.
            - Update with joint names for your robot (in order expected by rbt controller)
            - and uncomment the following line: -->
       <rosparam command="load" file="$(find myworkcell_moveit_config)/config/joint_names.yaml"/>
- 
+
       <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
       <!--  - if sim=false, a robot_ip argument is required -->
       <arg name="sim" default="true" />
       <arg name="robot_ip" unless="$(arg sim)" />
- 
+
       <!-- load the robot_description parameter before launching ROS-I nodes -->
       <include file="$(find myworkcell_moveit_config)/launch/planning_context.launch" >
        <arg name="load_robot_description" value="true" />
@@ -152,9 +152,9 @@ To do this, we need to define a few extra files.
       </include>
 
       <include file="$(find myworkcell_moveit_config)/launch/moveit_rviz.launch">
-        <arg name="config" value="true"/>
+        <!-- <arg name="config" value="true"/> -->
       </include>
-  
+
     </launch>
     ```
 

--- a/gh_pages/_source/session5/OpenCV-in-Python.md
+++ b/gh_pages/_source/session5/OpenCV-in-Python.md
@@ -25,7 +25,7 @@ In this exercise, you will create a new node to determine the angular pose of a 
   1. Estimate primary axis using bounding box
   1. Determine orientation using piston sleeve locations
   1. Calculate the axis orientation relative to a reference (horizontal) axis
-  
+
 ![pump images](../../_static/pump_images.png)
 
 ## Implementation
@@ -323,7 +323,7 @@ The next node will subscribe to the `image` topic and execute a series of proces
     # threshold grayscale to binary (black & white) image
     threshVal = 75
     ret,thresh = cv2.threshold(gray, threshVal, 255, cv2.THRESH_BINARY)
-    drawImg = cv2.cvtColor(thresh, cv2.COLOR_GRAY2BGR) 
+    drawImg = cv2.cvtColor(thresh, cv2.COLOR_GRAY2BGR)
     ```
 
     You should experiment with the `threshVal` paramter to find a value that works best for this image.  Valid values for this parameter lie between [0-255], to match the grayscale pixel intensity range.  Find a value that clearly highlights the pump face geometry.  I found that a value of `150` seemed good to me.
@@ -382,9 +382,9 @@ The next node will subscribe to the `image` topic and execute a series of proces
        # detect blobs inside pump body
        pistonArea = 3.14159 * PISTON_DIAMETER**2 / 4
        blobParams = cv2.SimpleBlobDetector_Params()
-       blobParams.filterByArea = True;
-       blobParams.minArea = 0.80 * pistonArea;
-       blobParams.maxArea = 1.20 * pistonArea;
+       blobParams.filterByArea = True
+       blobParams.minArea = 0.80 * pistonArea
+       blobParams.maxArea = 1.20 * pistonArea
        blobDetector = cv2.SimpleBlobDetector_create(blobParams)
        blobs = blobDetector.detect(thresh)
        ```
@@ -513,4 +513,3 @@ For a greater challenge, try the following suggestions to modify the operation o
  1. Change the `detect_pump` node to provide a **service** that performs the image detection.  Define a custom service type that takes an input image and outputs the pump angle.  Create a new application node that subscribes to the `image` topic and calls the `detect_pump` service.
 
  1. Try using `HoughCircles` instead of `BlobDetector` to locate the piston sleeves.
-


### PR DESCRIPTION
# **Description**
This pull request corrects __2 documentation errors__ in the industrial training for ROS Melodic.

# **Modifications Made**
## Under `Build a MoveIt! Package` in [Exercise 3.3](https://industrial-training-master.readthedocs.io/en/melodic/_source/session3/Build-a-Moveit!-Package.html)

 **Commented** out the following line:
`<arg name="config" value="true"/>`
This line is found under instruction 4 of [Using MoveIt with Physical Hardware](https://github.com/ros-industrial/industrial_training/blob/melodic/gh_pages/_source/session3/Build-a-Moveit!-Package.md#using-moveit-with-physical-hardware).

#### **[Rationale]**
Leaving that argument xml tag in would cause the following error when running the command `roslaunch myworkcell_moveit_config myworkcell_planning_execution.launch` in the instruction after instruction 4:
```
Unused arg "config" passed to moveit_rviz.launch
```

## Under `OpenCV Image Processing (Python)` in [Exercise 5.4](https://industrial-training-master.readthedocs.io/en/melodic/_source/session5/OpenCV-in-Python.html)

**Removed** the semi-colons in the python source code under instruction 8 of [Create The Detect Pump Image-Processing Node](https://github.com/ros-industrial/industrial_training/blob/melodic/gh_pages/_source/session5/OpenCV-in-Python.md#create-the-detect_pump-image-processing-node).

#### **[Rationale]**
While the python code is unaffected by the semi-colons, participants who are not python users are understandably confused when python code is mixed with C++ syntax. 