### PR TITLE
update check script to temp DISABLE some tests

### DIFF
--- a/.check_training_config.bash
+++ b/.check_training_config.bash
@@ -16,6 +16,11 @@ function print_result() {
   fi
 }
 
+# replace print_result() call with print_disabled() call to temporarily disable a test
+function print_disabled() {
+  echo -e "\e[00;30m[DISABLED]\e[00m"
+}
+
 function check_internet() {
   echo "Checking internet connection... "
   printf "  - %-30s" "google.com:"
@@ -63,6 +68,11 @@ function check_deb() {
   print_result $(dpkg-query -s $1 &> /dev/null)
 }
 
+function disable_deb() {
+  printf "  - %-30s" "$1:"
+  print_disabled $(dpkg-query -s $1 &> /dev/null)
+}
+
 function check_debs() {
   echo "Checking debian packages... "
   check_deb git
@@ -77,11 +87,11 @@ function check_debs() {
   check_deb ros-$ROS_RELEASE-desktop
   check_deb ros-$ROS_RELEASE-perception
   check_deb ros-$ROS_RELEASE-moveit
-  check_deb ros-$ROS_RELEASE-industrial-core
-  check_deb ros-$ROS_RELEASE-openni-launch
-  check_deb ros-$ROS_RELEASE-openni-camera
-  check_deb ros-$ROS_RELEASE-openni2-launch
-  check_deb ros-$ROS_RELEASE-openni2-launch
+  disable_deb ros-$ROS_RELEASE-industrial-core
+  disable_deb ros-$ROS_RELEASE-openni-launch
+  disable_deb ros-$ROS_RELEASE-openni-camera
+  disable_deb ros-$ROS_RELEASE-openni2-launch
+  disable_deb ros-$ROS_RELEASE-openni2-launch
   echo "Checking ROS2 packages:"
   check_deb python3-colcon-bash
   check_deb python3-colcon-core
@@ -93,13 +103,13 @@ function check_bashrc() {
   echo "Checking .bashrc... "
   printf "  - %-30s" "\$ROS_VERSION:"
   if [ -z ${ROS_VERSION+x} ]; then
-	print_result $(false)
+	print_disabled $(false)
   else
 	print_result $([ $ROS_VERSION == "2" ])
   fi
   printf "  - %-30s" "\$ROS_DISTRO:"
   if [ -z ${ROS_DISTRO+x} ]; then
-	print_result $(false)
+	print_disabled $(false)
   else
 	print_result $([ $ROS_DISTRO == "$ROS2_RELEASE" ])
   fi
@@ -108,7 +118,7 @@ function check_bashrc() {
 function check_qtc() {
   echo "Checking for QTCreator w/ ROS plugin... "
   printf "  - %-30s" "qtcreator-ros:"
-  print_result $( which qtcreator-ros )
+  print_result $( [ `which qtcreator-ros` ] || [ -f "$HOME/QtCreator/latest/bin/qtcreator-ros" ] )
 }
 
 

--- a/gh_pages/_source/setup/PC-Setup---ROS.md
+++ b/gh_pages/_source/setup/PC-Setup---ROS.md
@@ -30,7 +30,7 @@ On most new systems, Virtual Box and VMs work out of the box.  The following is 
   * Virtualization must be enabled - Older systems do not have virtualization enabled (by default).  Virtualization must be enabled in the BIOS.  See <http://www.sysprobs.com/disable-enable-virtualization-technology-bios> for more information.
 
 ## Direct Linux PC Configuration
-An installation [shell script](https://github.com/ros-industrial/industrial_training/blob/melodic/gh_pages/_downloads/ros-industrial-training-setup.sh)
+An installation [shell script](https://github.com/ros-industrial/industrial_training/blob/foxy/gh_pages/_downloads/ros-industrial-training-setup.sh)
 is provided to run in Ubuntu Linux 20.04 LTS (Focal). This script installs ROS and any other packages needed for the environment used for this training.
 
 After this step (or if you already have a working ROS environment), clone the training material repository into your home directory:


### PR DESCRIPTION
- no binary debs released: industrial_core, openni_*
- no .bashrc check (messy to auto-source with dual ROS1/2 install)