### PR TITLE
Fix minor instruction errors/omissions (Foxy)

### DIFF
--- a/gh_pages/_source/session1/ros2/4-Topics-and-Messages.md
+++ b/gh_pages/_source/session1/ros2/4-Topics-and-Messages.md
@@ -36,7 +36,7 @@ Your goal is to create your first ROS subscriber:
    1. Add the package to the list of dependencies of the _vision_node_ target:
 
       ``` cmake
-      ament_target_dependencies(vision_node PUBLIC rclcpp fake_ar_publisher)
+      ament_target_dependencies(vision_node rclcpp fake_ar_publisher)
       ```
 
 1. Add a dependency in your package's `package.xml`:

--- a/gh_pages/_source/session2/ros2/0-Services.md
+++ b/gh_pages/_source/session2/ros2/0-Services.md
@@ -105,7 +105,7 @@ Your goal is to create a more intricate system of nodes:
       rosidl_target_interfaces(vision_node ${PROJECT_NAME} "rosidl_typesupport_cpp")
       ```
 
-1. NOW! you have a service defined in you package and you can attempt to _build_ the code to generate the service:
+1. Now you have a service defined in you package and you can attempt to _build_ the code to generate the service:
    
    ```
    colcon build

--- a/gh_pages/_source/session2/ros2/3-Parameters.md
+++ b/gh_pages/_source/session2/ros2/3-Parameters.md
@@ -70,7 +70,7 @@ So far we haven't used the request field, `base_frame`, for anything. In this ex
    {
      ...
      request->base_frame = base_frame;
-     RCLCPP_INFO_STREAM("Requesting pose in base frame: " << base_frame);
+     RCLCPP_INFO_STREAM(get_logger(), "Requesting pose in base frame: " << base_frame);
      ...
    }
 

--- a/gh_pages/_source/session3/ros2/1-Workcell-XACRO.md
+++ b/gh_pages/_source/session3/ros2/1-Workcell-XACRO.md
@@ -34,6 +34,7 @@ Specifically, you will need to:
        ```
        cd ~/ros2_ws/src
        git clone -b ros2 https://github.com/jdlangs/universal_robot.git
+       cd ~/ros2_ws
        colcon build
        source ~/ros2_ws/install/setup.bash
        ```
@@ -130,6 +131,12 @@ Specifically, you will need to:
                 output='screen',
             )
         ])
+    ```
+
+ 1. Add the urdf folder to the installation rule in your `CMakeLists.txt` so it gets installed where the launch file expects it to be.
+
+    ``` cmake
+    install(DIRECTORY launch urdf DESTINATION share/${PROJECT_NAME}/)
     ```
 
  1. Rebuild your workspace and check the updated URDF in RViz, using the launch file you just created:


### PR DESCRIPTION
All changes are to sphinx pages only. Code in exercise directory has the correct lines.

- 1.4: Removed PUBLIC keyword from `ament_target_dependencies` call
- 2.0: Fixed typo. "NOW! you have..." -> "Now you have"
- 2.3: Add `get_logger()` as first argument to `RCLCPP_INFO_STREAM`
- 3.1: Add `cd ~/ros2_ws` before building. Add instruction to update CMake installation rule to include urdf directory