### PR TITLE
Fix - Added moveit ros perception run-time dependency

### DIFF
--- a/exercises/Perception-Driven_Manipulation/ros2/solution_ws/src/pick_and_place_application/package.xml
+++ b/exercises/Perception-Driven_Manipulation/ros2/solution_ws/src/pick_and_place_application/package.xml
@@ -34,6 +34,7 @@
   <exec_depend>warehouse_ros_mongo</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>rviz2</exec_depend>  
+  <exec_depend>moveit_ros_perception</exec_depend> 
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_occupancy_map_monitor</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>

--- a/exercises/Perception-Driven_Manipulation/ros2/template_ws/src/pick_and_place_application/package.xml
+++ b/exercises/Perception-Driven_Manipulation/ros2/template_ws/src/pick_and_place_application/package.xml
@@ -34,6 +34,7 @@
   <exec_depend>warehouse_ros_mongo</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>rviz2</exec_depend>  
+  <exec_depend>moveit_ros_perception</exec_depend> 
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_occupancy_map_monitor</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>


### PR DESCRIPTION
This PR adds the ```moveit_ros_perception``` exec dependency to the **pick_and_place_application** package.  This dependency is needed to enable collision avoidance against the octomap produced from the fake point cloud