### PR TITLE
Update Exercise 7.2 gh_pages instructions to purge and resinstall `ros2_control`

### DIFF
--- a/gh_pages/_source/session7/ROS1-ROS2-bridge.md
+++ b/gh_pages/_source/session7/ROS1-ROS2-bridge.md
@@ -312,7 +312,7 @@ At the end of Exercise 7.2, the last instruction will remind you to reinstall `r
     echo $CMAKE_PREFIX_PATH | tr ':' '\n'
     ```
 
-1.  Build the bridge. This may take a while since it is creating mappings between all known message
+1.  Build the bridge. This may take a while (~30 min) since it is creating mappings between all known message
     and service types.
     ```
     cd ~/ros1_bridge_ws

--- a/gh_pages/_source/session7/ROS1-ROS2-bridge.md
+++ b/gh_pages/_source/session7/ROS1-ROS2-bridge.md
@@ -356,11 +356,9 @@ At the end of Exercise 7.2, the last instruction will remind you to reinstall `r
 
 ### Run the ROS1 bridge
 
-1.  In your ros1_bridge_ws ROS2 workspace, source the ROS1, ROS2, and bridge workspaces if you have not already.
+1.  In your ros1_bridge_ws ROS2 workspace, source the workspace if you have not already.
     ```
     cd ~/ros1_bridge_ws
-    source ~/catkin_ws_to_bridge/devel/setup.bash
-    source ~/colcon_ws/install/setup.bash
     source install/setup.bash
     ```
 


### PR DESCRIPTION
In addition to minor `gh_pages` description improvements for Exercise 7.2, this PR's primary purpose is to address the build issue raised by @zoss in [#367](https://github.com/ros-industrial/industrial_training/pull/367#issuecomment-940742145). Testing in a root AWS instance of this training, I verified that the command to purge the `ros2_control` package causing the error could be reinstalled later at the end of Exercise 7.2. This is a workaround that probably needs to be addressed with further development of the `ros1_bridge`. @jdlangs  may have additional thoughts on this.

**Primary additional instructions provided in this PR:**

Remove the package causing the issue and 5 other packages before building the `ros1_bridge`:
```
sudo apt purge ros-foxy-controller-manager-msgs --autoremove
```

Re-install `ros2_control` and the other 5 packages that were removed at the end of Exercise 7.2:
```
sudo apt install ros-foxy-ros2-control
```