### PR TITLE
Updated the Universal Robots ROS2 repository

### DIFF
--- a/exercises/Perception-Driven_Manipulation/ros2/solution_ws/src/dependencies.repos
+++ b/exercises/Perception-Driven_Manipulation/ros2/solution_ws/src/dependencies.repos
@@ -5,8 +5,8 @@ repositories:
     version: master
   Universal_Robots_ROS2_Driver:
     type: git
-    url: https://github.com/jrgnicho/Universal_Robots_ROS2_Driver.git
-    version: feature-allow-using-init-positions-file
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+    version: foxy
   ur_msgs:
     type: git
     url: https://github.com/destogl/ur_msgs.git

--- a/exercises/Perception-Driven_Manipulation/ros2/template_ws/src/dependencies.repos
+++ b/exercises/Perception-Driven_Manipulation/ros2/template_ws/src/dependencies.repos
@@ -5,8 +5,8 @@ repositories:
     version: master
   Universal_Robots_ROS2_Driver:
     type: git
-    url: https://github.com/jrgnicho/Universal_Robots_ROS2_Driver.git
-    version: feature-allow-using-init-positions-file
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+    version: foxy
   ur_msgs:
     type: git
     url: https://github.com/destogl/ur_msgs.git


### PR DESCRIPTION
The [patch to the Universal Robot ROS2 repo](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/219) was applied and now it allows passing an initial pose for the arm which is a feature needed for the pick and place demo so that the robot does not start in collision