### PR TITLE
Deprecate tf2 C Headers

### DIFF
--- a/exercises/5.1/solution_ws/ros2/src/lesson_perception/src/perception_node.cpp
+++ b/exercises/5.1/solution_ws/ros2/src/lesson_perception/src/perception_node.cpp
@@ -1,5 +1,5 @@
 #include "rclcpp/rclcpp.hpp"
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -18,9 +18,9 @@
 #include <pcl/segmentation/extract_clusters.h>
 #include <pcl/filters/crop_box.h>
 #include <pcl/filters/statistical_outlier_removal.h>
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 #include <tf2_eigen/tf2_eigen.h>
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.hpp>
 #include <pcl/segmentation/extract_polygonal_prism_data.h>
 
 class PerceptionNode : public rclcpp::Node

--- a/exercises/5.1/template_ws/ros2/lesson_perception/src/perception_node.cpp
+++ b/exercises/5.1/template_ws/ros2/lesson_perception/src/perception_node.cpp
@@ -1,5 +1,5 @@
 #include "rclcpp/rclcpp.hpp"
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -18,9 +18,9 @@
 #include <pcl/segmentation/extract_clusters.h>
 #include <pcl/filters/crop_box.h>
 #include <pcl/filters/statistical_outlier_removal.h>
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.hpp>
 #include <pcl/segmentation/extract_polygonal_prism_data.h>
 
 class PerceptionNode : public rclcpp::Node
@@ -166,7 +166,7 @@ class PerceptionNode : public rclcpp::Node
         }
 
         void publishPointCloud(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr publisher,
-                               pcl::PointCloud<pcl::PointXYZ> point_cloud) 
+                               pcl::PointCloud<pcl::PointXYZ> point_cloud)
         {
 
             sensor_msgs::msg::PointCloud2::SharedPtr pc2_cloud(new sensor_msgs::msg::PointCloud2);

--- a/exercises/5.1/template_ws/ros2/lesson_perception/src/perception_node.cpp
+++ b/exercises/5.1/template_ws/ros2/lesson_perception/src/perception_node.cpp
@@ -166,7 +166,7 @@ class PerceptionNode : public rclcpp::Node
         }
 
         void publishPointCloud(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr publisher,
-                               pcl::PointCloud<pcl::PointXYZ> point_cloud)
+                               pcl::PointCloud<pcl::PointXYZ> point_cloud) 
         {
 
             sensor_msgs::msg::PointCloud2::SharedPtr pc2_cloud(new sensor_msgs::msg::PointCloud2);

--- a/exercises/5.3/solution_ws/ros2/src/py_perception/src/py_perception_node.cpp
+++ b/exercises/5.3/solution_ws/ros2/src/py_perception/src/py_perception_node.cpp
@@ -1,6 +1,6 @@
 #include "py_perception/srv/filter_cloud.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -19,9 +19,9 @@
 #include <pcl/segmentation/extract_clusters.h>
 #include <pcl/filters/crop_box.h>
 #include <pcl/filters/statistical_outlier_removal.h>
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 #include <tf2_eigen/tf2_eigen.h>
-#include "tf2/LinearMath/Quaternion.h"
+#include "tf2/LinearMath/Quaternion.hpp"
 #include <pcl/segmentation/extract_polygonal_prism_data.h>
 
 class PerceptionNode : public rclcpp::Node

--- a/exercises/5.3/template_ws/ros2/src/py_perception/src/py_perception_node.cpp
+++ b/exercises/5.3/template_ws/ros2/src/py_perception/src/py_perception_node.cpp
@@ -1,6 +1,6 @@
 #include "py_perception/srv/filter_cloud.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -19,9 +19,9 @@
 #include <pcl/segmentation/extract_clusters.h>
 #include <pcl/filters/crop_box.h>
 #include <pcl/filters/statistical_outlier_removal.h>
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 #include <tf2_eigen/tf2_eigen.h>
-#include "tf2/LinearMath/Quaternion.h"
+#include "tf2/LinearMath/Quaternion.hpp"
 #include <pcl/segmentation/extract_polygonal_prism_data.h>
 
 class PerceptionNode : public rclcpp::Node

--- a/exercises/8.0/template/snp_tpp/src/roi_selection_mesh_modifier.cpp
+++ b/exercises/8.0/template/snp_tpp/src/roi_selection_mesh_modifier.cpp
@@ -1,6 +1,6 @@
 #include <snp_tpp/roi_selection_mesh_modifier.h>
 #include <tf2_eigen/tf2_eigen.h>
-#include <tf2/time.h>
+#include <tf2/time.hpp>
 
 namespace snp_tpp
 {

--- a/exercises/Perception-Driven_Manipulation/ros2/solution_ws/src/pick_and_place_application/include/pick_and_place_application/pick_and_place_utilities.h
+++ b/exercises/Perception-Driven_Manipulation/ros2/solution_ws/src/pick_and_place_application/include/pick_and_place_application/pick_and_place_utilities.h
@@ -5,9 +5,9 @@
 
 #include <geometry_msgs/msg/pose.hpp>
 
-#include <tf2/transform_datatypes.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Vector3.h>
+#include <tf2/transform_datatypes.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
 
 #include <moveit_msgs/msg/attached_collision_object.hpp>
 #include <moveit_msgs/msg/constraints.hpp>

--- a/exercises/Perception-Driven_Manipulation/ros2/template_ws/src/pick_and_place_application/include/pick_and_place_application/pick_and_place_utilities.h
+++ b/exercises/Perception-Driven_Manipulation/ros2/template_ws/src/pick_and_place_application/include/pick_and_place_application/pick_and_place_utilities.h
@@ -5,9 +5,9 @@
 
 #include <geometry_msgs/msg/pose.hpp>
 
-#include <tf2/transform_datatypes.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Vector3.h>
+#include <tf2/transform_datatypes.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
 
 #include <moveit_msgs/msg/attached_collision_object.hpp>
 #include <moveit_msgs/msg/constraints.hpp>


### PR DESCRIPTION
Related to this [pull request](https://github.com/ros2/geometry2/pull/720) in `geometry2` in which we deprecated the `.h` style headers in favor of `.hpp`.

Edit: I should mention this is meant to be a preemptive PR for if/when the related pull request gets approved. I'm also working on a backport so there won't be distribution issues