### PR TITLE
Fix typo in script name from images_to_bag.py to images_to_bags.py

### DIFF
--- a/gh_pages/_source/session9/Cameras-and-Calibration.md
+++ b/gh_pages/_source/session9/Cameras-and-Calibration.md
@@ -83,7 +83,7 @@ The way we get the Focal length, principal point, and distortion  parameters is 
     ```
     source /opt/ros/humble/setup.bash
     cd ~/industrial_training/exercises/9.0
-    python3 images_to_bag.py
+    python3 images_to_bags.py
     cp -r ./intrinsics_rosbag* ~/calibration_ws
     ```
 


### PR DESCRIPTION
Noticed the command in the guide was missing an 's', making the script fail when copied.

<img width="1869" height="1327" alt="Screenshot 2026-04-14 145429" src="https://github.com/user-attachments/assets/98ce0f4d-9743-4daa-b607-734641014152" />
